### PR TITLE
map returns a one-shot iterator now; convert to list to be able to iterate it more than once

### DIFF
--- a/code/buffer_filter.py
+++ b/code/buffer_filter.py
@@ -4,7 +4,7 @@ import re
 class BufferFilter:
     def __init__(self, exclude_pattern=None, exclude_patterns=[]):
         self.exclude_pattern = re.compile(exclude_pattern) if exclude_pattern is not None else None
-        self.exclude_patterns = map(lambda p: re.compile(p), exclude_patterns)
+        self.exclude_patterns = list(map(lambda p: re.compile(p), exclude_patterns))
         self.buffer = []
         self.file_buffer = []
         self.chunk_buffer = []


### PR DESCRIPTION
I think this is a python 3 change; with just this change I was able to use the script successfully on Python 3.9.7.